### PR TITLE
Database Migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# Rust API
+
+This is a simple API written in [Rust](https://www.rust-lang.org/).
+
+## How to run
+
+This code is using a [PostgreSQL](https://www.postgresql.org/) container in [Docker](https://www.docker.com/).
+
+### Docker
+
+To start the PostgreSQL container:
+
+`docker-compose -f up -d`
+
+To end the container:
+
+`docker-compose -f down`
+
+### Cargo
+
+After the container is running, you can execute the application using the following command:
+
+`cargo run`
+
+## Migrations
+
+Generate reversible migration scripts containing both "up" and "down" SQL files:
+
+`sqlx migrate add -r "description"`
+
+To syncronize the database schema with the migration scripts in "`./migrations`", execute:
+
+`sqlx migrate run`

--- a/migrations/20240504175007_Countries.down.sql
+++ b/migrations/20240504175007_Countries.down.sql
@@ -1,0 +1,4 @@
+-- Add down migration script here
+DROP TABLE IF EXISTS countries;
+
+DROP EXTENSION IF EXISTS "uuid-ossp";

--- a/migrations/20240504175007_Countries.up.sql
+++ b/migrations/20240504175007_Countries.up.sql
@@ -1,0 +1,11 @@
+-- Add up migration script here
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+CREATE TABLE countries
+(
+    id        UUID         NOT NULL PRIMARY KEY DEFAULT (uuid_generate_v4()),
+    name      VARCHAR(100) NOT NULL UNIQUE,
+    alpha_2   VARCHAR(2)   NOT NULL UNIQUE,
+    alpha_3   VARCHAR(3)   NOT NULL UNIQUE,
+    numeric_3 VARCHAR(3)   NOT NULL UNIQUE
+);

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,10 +37,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .connect(&config.database_url)
         .await?;
 
-    // match sqlx::migrate!("./migrations").run(&pool).await {
-    //     Ok(_) => println!("Migrations executed successfully."),
-    //     Err(e) => eprintln!("Error executing migrations: {}", e),
-    // };
+    match sqlx::migrate!("./migrations").run(&pool).await {
+        Ok(_) => println!("Migrations executed successfully."),
+        Err(e) => eprintln!("Error executing migrations: {}", e),
+    };
 
     let db_client = DBClient::new(pool);
     let app_state: AppState = AppState {


### PR DESCRIPTION
As migrations serão aplicadas automaticamente ao executar a aplicação utilizando `cargo run`.

Para criar uma migration, utilize o comando: `sqlx migrate add -r "descricao_da_migration"`.

Se preferir, é possível aplicar as migrations sem inicializar a aplicação: `sqlx migrate run`.

## Observação

Aguardar a conclusão do PR #12  para prosseguir com o flow aqui.